### PR TITLE
Fixed incorrect pluralization of LocalDjangoCommunity in admin - Issu…

### DIFF
--- a/aggregator/models.py
+++ b/aggregator/models.py
@@ -226,6 +226,7 @@ class LocalDjangoCommunity(models.Model):
     created_at = models.DateTimeField(auto_now_add=True)
 
     class Meta:
+        verbose_name_plural = _("Local Django Communities")
         constraints = [
             models.CheckConstraint(
                 check=(


### PR DESCRIPTION
Solved - #1739

Added verbose_name_plural = _("Local Django Communities") in the Meta class

![image](https://github.com/user-attachments/assets/12e285d6-f5cf-4c3d-9e21-0e42c6737a29)


Ensured from django.utils.translation import gettext_lazy as _ is there at the top.

## Summary by Sourcery

Bug Fixes:
- Corrected the pluralization of 'LocalDjangoCommunity' in the admin interface by adding 'verbose_name_plural' to the Meta class.